### PR TITLE
Fixed missing title and missing lead in bajnokok ligaja articles

### DIFF
--- a/summarization/html_parsers/m4sport_parser.py
+++ b/summarization/html_parsers/m4sport_parser.py
@@ -17,6 +17,9 @@ class M4SportParser(ParserBase):
             title = next(iter(soup.select('div.articleHead > div.articleMeta > h1')), None)
 
         if not title:
+            title = soup.find('h2', class_='hms_article_title')
+
+        if not title:
             title = soup.find('div', class_='titletextm4-redesign')
 
         if not title:
@@ -32,6 +35,9 @@ class M4SportParser(ParserBase):
 
     def get_lead(self, soup) -> str:
         lead = soup.find('span', class_='hms_article_lead_text')
+
+        if not lead:
+            lead = next(iter(soup.select('div.hms_article_lead_content > span.hms_article_lead_text')), None)
 
         if not lead:
             leads = soup.select('div.articleContent > strong > p')


### PR DESCRIPTION
This was a bug I found in the M4 parser looking at the logs. All the other things look fine to me. The big drop in articles while parsing, should be due to a lot of videos, livestreams and galleries since it's a sport related site.